### PR TITLE
updated README to not include abc stuff in the celery example

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,17 +52,15 @@ In order to change the duration of a lock, set the DB_MUTEX_TTL_SECONDS variable
 Django DB Mutex can be used with celery's tasks in the following manner.
 
     from celery import Task
-    from abc import ABCMeta, abstractmethod
 
     class NonOverlappingTask(Task):
         __metaclass__ = ABCMeta
 
-        @abstractmethod
         def run_worker(self, *args, **kwargs):
             """
             Run worker code here.
             """
-            pass
+            raise NotImplementedError()
 
         def run(self, *args, **kwargs):
             try:


### PR DESCRIPTION
@jaredlewis, @joshmarlow, I went ahead and removed the abc stuff from the README in this project just so it is accurate
