### PR TITLE
Fixes #22 by using django.utils.timezone.now()

### DIFF
--- a/db_mutex/db_mutex.py
+++ b/db_mutex/db_mutex.py
@@ -1,9 +1,10 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 import functools
 import logging
 
 from django.conf import settings
 from django.db import transaction, IntegrityError
+from django.utils import timezone
 
 from .exceptions import DBMutexError, DBMutexTimeoutError
 from .models import DBMutex
@@ -83,7 +84,7 @@ class db_mutex(object):
         """
         ttl_seconds = self.get_mutex_ttl_seconds()
         if ttl_seconds is not None:
-            DBMutex.objects.filter(creation_time__lte=datetime.utcnow() - timedelta(seconds=ttl_seconds)).delete()
+            DBMutex.objects.filter(creation_time__lte=timezone.now() - timedelta(seconds=ttl_seconds)).delete()
 
     def __call__(self, func):
         return self.decorate_callable(func)


### PR DESCRIPTION
If you're using timezone aware dates and times in Django, db_mutex throws up an exception when deleting expired locks and the ORM is given a naive datetime:

/home/justin/.virtualenvs/archimedes/local/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1474: RuntimeWarning: DateTimeField DBMutex.creation_time received a naive datetime (2016-01-27 23:56:26.813847) while time zone support is active.
  RuntimeWarning)

I've fixed this by using [Django's timezone.now utility](https://docs.djangoproject.com/en/1.8/ref/utils/#django.utils.timezone.now)

See #22 