### PR TITLE
Fixed flake errors by reordering imports and marking #noqa

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -14,7 +14,7 @@ configure_settings()
 django.setup()
 
 # Django nose must be imported here since it depends on the settings being configured
-from django_nose import NoseTestSuiteRunner
+from django_nose import NoseTestSuiteRunner  # noqa
 
 
 def run_tests(*test_args, **kwargs):

--- a/settings.py
+++ b/settings.py
@@ -49,7 +49,7 @@ def configure_settings():
                 'django_nose',
             ),
             DEBUG=False,
-            CACHES = {
+            CACHES={
                 'default': {
                     'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
                     'LOCATION': 'unique-snowflake'

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 # import multiprocessing to avoid this bug (http://bugs.python.org/issue15881#msg170215)
-import multiprocessing
-assert multiprocessing
 import re
 from setuptools import setup, find_packages
+import multiprocessing
+assert multiprocessing
 
 
 def get_version():


### PR DESCRIPTION
The Travis CI builds are showing a number of flake errors on the develop branch - e.g. https://travis-ci.org/ambitioninc/django-db-mutex/jobs/105329249

This pull fixes those errors by re-ordering some of the imports, and marking some with `#noqa`