### PR TITLE
Declare app_label in model Meta class to work with Django 1.9

### DIFF
--- a/db_mutex/models.py
+++ b/db_mutex/models.py
@@ -13,3 +13,6 @@ class DBMutex(models.Model):
     """
     lock_id = models.CharField(max_length=256, unique=True)
     creation_time = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        app_label = 'db_mutex'


### PR DESCRIPTION
Fixes RemovedInDjango19Warning:

Model class db_mutex.models.DBMutex doesn't declare an explicit
app_label and either isn't in an application in INSTALLED_APPS or else
was imported before its application was loaded.  This will no longer be
supported in Django 1.9.

Credit: https://github.com/minervaproject/django-db-mutex/commit/429d701cce7ad2cf8fb77f169c4af6f2f27562fd