### PR TITLE
Attempting to fix Django 1.9 issues

### DIFF
--- a/db_mutex/db_mutex.py
+++ b/db_mutex/db_mutex.py
@@ -7,7 +7,6 @@ from django.db import transaction, IntegrityError
 from django.utils import timezone
 
 from .exceptions import DBMutexError, DBMutexTimeoutError
-from .models import DBMutex
 
 
 LOG = logging.getLogger(__name__)
@@ -82,6 +81,7 @@ class db_mutex(object):
         """
         Deletes all expired mutex locks if a ttl is provided.
         """
+        from .models import DBMutex
         ttl_seconds = self.get_mutex_ttl_seconds()
         if ttl_seconds is not None:
             DBMutex.objects.filter(creation_time__lte=timezone.now() - timedelta(seconds=ttl_seconds)).delete()
@@ -102,6 +102,7 @@ class db_mutex(object):
         """
         # Delete any expired locks first
         self.delete_expired_locks()
+        from .models import DBMutex
         try:
             with transaction.atomic():
                 self.lock = DBMutex.objects.create(lock_id=self.lock_id)
@@ -112,6 +113,7 @@ class db_mutex(object):
         """
         Releases the db mutex lock. Throws an error if the lock was released before the function finished.
         """
+        from .models import DBMutex
         if not DBMutex.objects.filter(id=self.lock.id).exists():
             raise DBMutexTimeoutError('Lock {0} expired before function completed'.format(self.lock_id))
         else:


### PR DESCRIPTION
There were some changes in the app loading process in Django 1.9.

The full docs can be found here:

https://docs.djangoproject.com/en/1.9/releases/1.9/

But the relevant part is here:

```
All models need to be defined inside an installed application or declare an explicit app_label. Furthermore, it isn’t possible to import them before their application is loaded. In particular, it isn’t possible to import models inside the root package of an application.
```

In short, the `db_mutex/__init__.py` file was importing `db_mutex.py` which directly imported `models.py`.

This PR moves model imports into local functions so that the file can be loaded from `__init__.py`.